### PR TITLE
[ FEAT ] Add default request

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,35 @@ this.state.baseUrl = 'reqres.in/api';
 Get /users/2
 ```
 
+#### Default
+
+Default is a variable that defines the request defaults
+
+```
+Get httpbin.org/get
+
+.js
+// In Node.js:
+// const b64 = Buffer.from('user:demo').toString('base64')
+
+const b64 = btoa('user:demo')
+this.state.b64 = b64
+this.state.default.headers.authorization = `Basic ${b64}`
+.
+
+---
+
+Get /basic-auth/user/demo
+
+# Default Apply:
+# authorization: Basic $b64
+user-agent: HTTP Script
+```
+
+Thus adding both the user-agent header and
+the authorization header
+
+
 ### Contributing
 
 Hi there!

--- a/src/httpScript.js
+++ b/src/httpScript.js
@@ -76,7 +76,7 @@ function addProtocol(url) {
 }
 
 function parseScript(script) {
-  const options = { ...REST_OPTIONS }
+  const options = { runJs: REST_OPTIONS.runJs }
 
   const regexMethod = /^([a-zA-Z]+) +(.*?)$/m
 
@@ -243,11 +243,28 @@ export default function httpScript(script, httpRequest = httpRequestDefault) {
   const parsedList = parseHttpScript(script)
 
   let state = {}
+  state.default = { ...REST_OPTIONS }
+
   let response = null
   let baseUrl = null
 
-  for (const parsed of parsedList) {
+  for (let parsed of parsedList) {
     parsed.state = state
+
+    parsed = {
+      ...parsed.state.default,
+      ...parsed,
+
+      queries: {
+        ...parsed.state.default.queries,
+        ...parsed.queries
+      },
+
+      headers: {
+        ...parsed.state.default.headers,
+        ...parsed.headers
+      },
+    }
 
     if (
       parsed.url.startsWith('http')

--- a/tests/httpScript.test.js
+++ b/tests/httpScript.test.js
@@ -283,7 +283,9 @@ function testVariables() {
 function testState() {
   console.log('Testing State...')
 
-  const result = httpScript(
+  let result
+
+  result = httpScript(
     'g :1234'
     + '\n'
     + '\n'
@@ -303,11 +305,68 @@ function testState() {
   assert.strictEqual(result.state.name, "John Due")
 }
 
+function testDefault() {
+  let result
+
+  result = httpScript(
+    'g :1234'
+    + '\n'
+    + '\n'
+    + '\n.js'
+    + '\nthis.state.default.headers.Auth = "XXX"'
+    + '\n.'
+    + '\n---'
+    + '\ng :1234'
+  )
+
+  assert.strictEqual(
+    result.state.default.headers.Auth,
+    'XXX'
+  )
+
+  assert.strictEqual(
+    result.headers.Auth,
+    'XXX'
+  )
+
+  result = httpScript(
+    'g :1234'
+    + '\n'
+    + '\n'
+    + '\n.js'
+    + '\nthis.state.default.headers.Auth = "XXX"'
+    + '\n.'
+    + '\n---'
+    + '\ng :1234'
+    + '\nAuth: 123'
+    + '\n'
+  )
+
+  assert.strictEqual(result.headers.Auth, '123')
+
+  result = httpScript(
+    'g :1234'
+    + '\n'
+    + '\n'
+    + '\n.js'
+    + '\nthis.state.default.headers.Auth = "XXX"'
+    + '\n.'
+    + '\n---'
+    + '\ng :1234'
+    + '\nUser-Agent: HTTP Script'
+    + '\n'
+  )
+
+  assert.strictEqual(result.headers.Auth, 'XXX')
+  assert.strictEqual(result.headers['User-Agent'], 'HTTP Script')
+}
+
 
 export default function testHttpScript() {
   testAutoBaseUrl()
   testVariables()
   testState()
+  testDefault()
 
   console.log('Tests httpScript OK\n')
 }


### PR DESCRIPTION
- **feat: add request default**
- **test: default requests from httpScript.js**
- **docs: example of using default requests**

### Description:
I added spred operators changing the defaults of  the `REQUEST_OPTIONS` constant to `parsed.state.default` giving priority to user overrides in the request

### Related Issue:
#8 Set requests by default

### How Was It Tested?
Yes, it has been tested to ensure that the expected default results are applied to request definitions that the user does not override.

### Checklist:
- [x] The code follows conventional commit guidelines.
- [x] Tests were added/updated.
- [x] Documentation was updated (if necessary).
